### PR TITLE
Ensure Handoff accepts a signed URL generated from another hostname

### DIFF
--- a/src/Http/Controllers/HandoffController.php
+++ b/src/Http/Controllers/HandoffController.php
@@ -28,7 +28,7 @@ class HandoffController
 
     protected function validateSignedURL(): void
     {
-        if (! URL::hasValidSignature($this->request)) {
+        if (! URL::hasValidSignature($this->request, false)) {
             abort(403, 'Invalid or expired Handoff redirect URL.');
         }
     }

--- a/tests/HandoffControllerTest.php
+++ b/tests/HandoffControllerTest.php
@@ -1,8 +1,13 @@
 <?php
 
-use ClarkeWing\Handoff\Actions\GenerateHandoffUrl;
 use ClarkeWing\Handoff\Tests\Fixtures\NonAuthenticatableUser;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\URL;
+use Spatie\Url\Url as Uri;
+
+beforeEach(function () {
+    config()->set('handoff.target_host', 'https://remote.app');
+});
 
 it('rejects missing signatures', function () {
     $this->get('/handoff?user=1&target=/dashboard')
@@ -18,11 +23,13 @@ it('rejects invalid signatures', function () {
 
 it('accepts a signed URL generated from another hostname', function () {
     setUrlRoot('http://foo.com');
-    config()->set('handoff.target_host', 'http://bar.com');
 
-    $url = resolve(GenerateHandoffUrl::class)->generate($this->testUser, toPath: '/dashboard');
+    $url = generateHandoffUrl(
+        user: $this->testUser->getAuthIdentifier(),
+        target: '/dashboard',
+    );
 
-    expect($url)->toStartWith('http://bar.com');
+    expect($url)->toStartWith('https://remote.app');
 
     $this->get($url)
         ->assertRedirect('/dashboard');
@@ -34,13 +41,10 @@ it('accepts a signed URL generated from another hostname', function () {
 
 it('rejects expired signed URLs', function () {
     // Create an expired signed URL
-    $url = URL::temporarySignedRoute(
-        'handoff',
-        now()->subMinute(), // Expired 1 minute ago
-        [
-            'user' => $this->testUser->getAuthIdentifier(),
-            'target' => '/dashboard',
-        ]
+    $url = generateHandoffUrl(
+        user: $this->testUser->getAuthIdentifier(),
+        target: '/dashboard',
+        expiry: now()->subMinute(),
     );
 
     $this->get($url)
@@ -50,12 +54,8 @@ it('rejects expired signed URLs', function () {
 
 it('requires a user parameter', function () {
     // Create a signed URL without a user parameter
-    $url = URL::temporarySignedRoute(
-        'handoff',
-        now()->addMinutes(5),
-        [
-            'target' => '/dashboard',
-        ]
+    $url = generateHandoffUrl(
+        target: '/dashboard',
     );
 
     $this->get($url)
@@ -64,13 +64,9 @@ it('requires a user parameter', function () {
 
 it('returns 404 when user is not found', function () {
     // Create a signed URL with a non-existent user ID
-    $url = URL::temporarySignedRoute(
-        'handoff',
-        now()->addMinutes(5),
-        [
-            'user' => 999, // Non-existent user ID
-            'target' => '/dashboard',
-        ]
+    $url = generateHandoffUrl(
+        user: 999,
+        target: '/dashboard',
     );
 
     $this->get($url)
@@ -78,13 +74,9 @@ it('returns 404 when user is not found', function () {
 });
 
 it('authenticates the user and redirects to the target path', function () {
-    $url = URL::temporarySignedRoute(
-        'handoff',
-        now()->addMinutes(5),
-        [
-            'user' => $this->testUser->getAuthIdentifier(),
-            'target' => '/dashboard',
-        ]
+    $url = generateHandoffUrl(
+        user: $this->testUser->getAuthIdentifier(),
+        target: '/dashboard',
     );
 
     $this->get($url)
@@ -97,13 +89,9 @@ it('authenticates the user and redirects to the target path', function () {
 });
 
 it('sanitizes target paths to prevent open redirect vulnerabilities', function () {
-    $url = URL::temporarySignedRoute(
-        'handoff',
-        now()->addMinutes(5),
-        [
-            'user' => $this->testUser->getAuthIdentifier(),
-            'target' => 'https://malicious-site.com',
-        ]
+    $url = generateHandoffUrl(
+        user: $this->testUser->getAuthIdentifier(),
+        target: 'https://malicious-site.com',
     );
 
     // Should redirect to root instead of the external URL
@@ -113,12 +101,8 @@ it('sanitizes target paths to prevent open redirect vulnerabilities', function (
 
 it('defaults to root path when target is not provided', function () {
     // Create a signed URL without a target parameter
-    $url = URL::temporarySignedRoute(
-        'handoff',
-        now()->addMinutes(5),
-        [
-            'user' => $this->testUser->getAuthIdentifier(),
-        ]
+    $url = generateHandoffUrl(
+        user: $this->testUser->getAuthIdentifier(),
     );
 
     $this->get($url)
@@ -129,13 +113,9 @@ it('throws exception when configured user model does not exist', function () {
     // Configure a non-existent user model
     config()->set('handoff.auth.model', 'App\\NonExistentModel');
 
-    $url = URL::temporarySignedRoute(
-        'handoff',
-        now()->addMinutes(5),
-        [
-            'user' => $this->testUser->getAuthIdentifier(),
-            'target' => '/dashboard',
-        ]
+    $url = generateHandoffUrl(
+        user: $this->testUser->getAuthIdentifier(),
+        target: '/dashboard',
     );
 
     $this->withoutExceptionHandling();
@@ -148,13 +128,9 @@ it('throws exception when configured user model does not implement Authenticatab
     // Configure the non-authenticatable user model
     config()->set('handoff.auth.model', NonAuthenticatableUser::class);
 
-    $url = URL::temporarySignedRoute(
-        'handoff',
-        now()->addMinutes(5),
-        [
-            'user' => 1,
-            'target' => '/dashboard',
-        ]
+    $url = generateHandoffUrl(
+        user: $this->testUser->getAuthIdentifier(),
+        target: '/dashboard',
     );
 
     $this->withoutExceptionHandling();
@@ -170,4 +146,28 @@ function setUrlRoot(string $root): void
     } else {
         URL::useOrigin($root);
     }
+}
+
+function generateHandoffUrl(int|string|null $user = null, ?string $target = null, ?Carbon $expiry = null): string
+{
+    $signedUrl = URL::temporarySignedRoute(
+        'handoff',
+        $expiry ?? now()->addSeconds(config('handoff.auth.ttl')),
+        array_filter([
+            'user' => $user,
+            'target' => $target,
+        ]),
+        absolute: false,
+    );
+
+    /** @var string $targetHost */
+    $targetHost = config('handoff.target_host');
+    $targetHost = Uri::fromString($targetHost);
+
+    $host = $targetHost->getHost();
+    $scheme = $targetHost->getScheme();
+
+    return (string) Uri::fromString($signedUrl)
+        ->withHost($host)
+        ->withScheme($scheme);
 }

--- a/tests/HandoffControllerTest.php
+++ b/tests/HandoffControllerTest.php
@@ -141,7 +141,7 @@ it('throws exception when configured user model does not implement Authenticatab
 
 function setUrlRoot(string $root): void
 {
-    if (laravelVersion() < 10) {
+    if (laravelVersion() < 11) {
         URL::forceRootUrl($root);
     } else {
         URL::useOrigin($root);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,7 @@
 <?php
 
 use ClarkeWing\Handoff\Tests\TestCase;
+use Illuminate\Support\Str;
 
 uses(TestCase::class)->in(__DIR__);
 
@@ -35,4 +36,9 @@ function getQueryParamValue(string $url, string $key): string|int|null
     return ($value = $params[$key]) === ''
         ? null
         : (is_numeric($value) ? (int) $value : $value);
+}
+
+function laravelVersion(): int
+{
+    return (int) Str::before(app()->version(), '.');
 }


### PR DESCRIPTION
This PR fixes an issue which occurred when another app using a different hostname generated the signed URL. It would then fail validation.